### PR TITLE
Fix style not loading error

### DIFF
--- a/src/app/esri-map/esri-map.component.css
+++ b/src/app/esri-map/esri-map.component.css
@@ -1,5 +1,5 @@
 /* import the required JSAPI css */
-@import 'https://js.arcgis.com/4.6/esri/css/main.css';
+@import url('https://js.arcgis.com/4.6/esri/css/main.css');
 
 .esri-view {
   height: 500px;

--- a/src/app/esri-map/esri-map.component.css
+++ b/src/app/esri-map/esri-map.component.css
@@ -1,5 +1,5 @@
 /* import the required JSAPI css */
-@import url('https://js.arcgis.com/4.6/esri/css/main.css');
+@import url('https://js.arcgis.com/4.10/esri/css/main.css');
 
 .esri-view {
   height: 500px;


### PR DESCRIPTION
Follow the style loading guide as of [ Esri Loading Styles](https://github.com/Esri/esri-loader#loading-styles)

`ng serve` output
`(1:1) Unable to find uri in '@import https://js.arcgis.com/4.6/esri/css/main.css'`

I also recommend to update the css to the latest version **4.10**