### PR TITLE
remove esri-loader and arcgis-webpack-plugin

### DIFF
--- a/extra-webpack.config.js
+++ b/extra-webpack.config.js
@@ -1,12 +1,8 @@
-const ArcGISPlugin = require('@arcgis/webpack-plugin');
-/**
- * Configuration items defined here will be appended to the end of the existing webpack config defined by the Angular CLI.
-*/
 module.exports = {
-    plugins: [new ArcGISPlugin()],
-    node: {
-      process: false,
-      global: false,
-      fs: "empty"
-    }
-  }
+  output: {
+    libraryTarget: 'amd-require'
+  },
+  externals: [
+    /^esri/i
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1021,45 +1021,6 @@
         "tslib": "^1.9.0"
       }
     },
-    "@arcgis/webpack-plugin": {
-      "version": "4.12.2",
-      "resolved": "https://registry.npmjs.org/@arcgis/webpack-plugin/-/webpack-plugin-4.12.2.tgz",
-      "integrity": "sha512-fEsiDyZA4Nx9kWoFtCNysz8MPpcc5wl9s8J7FKE16lsmBzjGInbIJE+xp6AdXZci74r+71Lr4puc3Jq77k+HaA==",
-      "dev": true,
-      "requires": {
-        "arcgis-js-api": "~4.12.0",
-        "copy-webpack-plugin": "^5.0.3",
-        "dojo-webpack-plugin": "^2.8.9",
-        "file-loader": "^1.1.11",
-        "null-loader": "^0.1.1",
-        "uglify-js": "^3.3.28",
-        "umd-compat-loader": "^2.1.1",
-        "url-loader": "^1.1.1",
-        "webpack-hasjs-plugin": "^1.0.3"
-      },
-      "dependencies": {
-        "file-loader": {
-          "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-1.1.11.tgz",
-          "integrity": "sha512-TGR4HU7HUsGg6GCOPJnFk06RhWgEWFLAGWiT6rcD+GRC2keU3s9RGJ+b3Z6/U73jwwNb2gKLJ7YCrp+jvU4ALg==",
-          "dev": true,
-          "requires": {
-            "loader-utils": "^1.0.2",
-            "schema-utils": "^0.4.5"
-          }
-        },
-        "schema-utils": {
-          "version": "0.4.7",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
-          "integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
-          "dev": true,
-          "requires": {
-            "ajv": "^6.1.0",
-            "ajv-keywords": "^3.1.0"
-          }
-        }
-      }
-    },
     "@babel/code-frame": {
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
@@ -1891,35 +1852,6 @@
         "to-fast-properties": "^2.0.0"
       }
     },
-    "@dojo/framework": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-5.0.4.tgz",
-      "integrity": "sha512-E8y+E6k6VgVOCiTQqokFEmxODuL4p6b7BroiGo5DNEgmS9dRMMHsO6UadDHx/TOsw47vP56Ly+ugHZbpS/XcWg==",
-      "dev": true,
-      "requires": {
-        "@types/cldrjs": "0.4.20",
-        "@types/globalize": "0.0.34",
-        "@webcomponents/webcomponentsjs": "1.1.0",
-        "cldrjs": "0.5.0",
-        "css-select-umd": "1.3.0-rc0",
-        "diff": "3.5.0",
-        "globalize": "1.4.0",
-        "intersection-observer": "0.4.2",
-        "pepjs": "0.4.2",
-        "resize-observer-polyfill": "1.5.0",
-        "tslib": "1.8.1",
-        "web-animations-js": "2.3.1",
-        "whatwg-fetch": "3.0.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.8.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.1.tgz",
-          "integrity": "sha1-aUavLR1lGnsYY7Ux1uWvpBqkTqw=",
-          "dev": true
-        }
-      }
-    },
     "@ngtools/webpack": {
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-8.3.4.tgz",
@@ -1964,12 +1896,6 @@
       "resolved": "https://registry.npmjs.org/@types/arcgis-js-api/-/arcgis-js-api-4.12.0.tgz",
       "integrity": "sha512-hNJnuqfM1BQZR+muyqFQp8Srw8rshOIsJbSTX2G2zstIj20k09LdwZNAAVYK/QXt90vIJAUnKqP+6JrBv5l/VA=="
     },
-    "@types/cldrjs": {
-      "version": "0.4.20",
-      "resolved": "https://registry.npmjs.org/@types/cldrjs/-/cldrjs-0.4.20.tgz",
-      "integrity": "sha512-vQe6BQF9QCHSLUlNjRa/1zicRCnQnTRwhW/FqgVv26A85COY1jfkkO6JjogDv22U3LRhu9pY4uPQOlxGnsuJPA==",
-      "dev": true
-    },
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
@@ -1985,15 +1911,6 @@
         "@types/events": "*",
         "@types/minimatch": "*",
         "@types/node": "*"
-      }
-    },
-    "@types/globalize": {
-      "version": "0.0.34",
-      "resolved": "https://registry.npmjs.org/@types/globalize/-/globalize-0.0.34.tgz",
-      "integrity": "sha512-FQTLuqZxqf+T1Ao6RzaIP7HcTcNvgDf0YQfK90YGYt1N6KeU5GE0M/hsxdQlpqvuztxjEwEQqIO3paSO/tZ4Pw==",
-      "dev": true,
-      "requires": {
-        "@types/cldrjs": "*"
       }
     },
     "@types/jasmine": {
@@ -2236,12 +2153,6 @@
         "@xtuc/long": "4.2.2"
       }
     },
-    "@webcomponents/webcomponentsjs": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-1.1.0.tgz",
-      "integrity": "sha512-7toNyVlrl7vJnY3PU0eXIK1KWq8phfnEe1IwOdCMxkIl/BfUkUB2aaVs45R0LSx1qxHRnkqj0vlGtskUvKkNkA==",
-      "dev": true
-    },
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -2413,25 +2324,6 @@
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
       "dev": true
     },
-    "arcgis-js-api": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/arcgis-js-api/-/arcgis-js-api-4.12.1.tgz",
-      "integrity": "sha512-u/wb0+R+dCmkUWv0XxypYY/GsP4b39J73eKo8W5PIg9M5UTPz2OqbjEHYMOJQjycU4zecxQ74xVBoCqBbFNawA==",
-      "dev": true,
-      "requires": {
-        "@dojo/framework": "5.0.4",
-        "dgrid": "github:Esri/dgrid#v1.2.1/esri-3.22.0",
-        "dijit": "github:Esri/dijit#v1.14.2/esri-3.28.0",
-        "dojo": "github:Esri/dojo#v1.14.2/esri-3.28.0",
-        "dojo-dstore": "1.1.2",
-        "dojo-util": "github:Esri/dojo-util#v1.14.2/esri-3.28.0",
-        "dojox": "github:Esri/dojox#v1.14.2/esri-3.28.0",
-        "maquette": "~3.3.2",
-        "maquette-css-transitions": "~1.1.0",
-        "maquette-jsx": "~2.1.1",
-        "moment": "2.24.0"
-      }
-    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -2571,12 +2463,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
-      "dev": true
-    },
-    "ast-types": {
-      "version": "0.9.14",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.14.tgz",
-      "integrity": "sha512-Ebvx7/0lLboCdyEmAw/4GqwBeKIijPveXNiVGhCGCNxc7z26T5he7DC6ARxu8ByKuzUZZcLog+VP8GMyZrBzJw==",
       "dev": true
     },
     "ast-types-flow": {
@@ -3058,12 +2944,6 @@
         "multicast-dns-service-types": "^1.1.0"
       }
     },
-    "boolbase": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
-      "dev": true
-    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -3446,12 +3326,6 @@
           }
         }
       }
-    },
-    "cldrjs": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cldrjs/-/cldrjs-0.5.0.tgz",
-      "integrity": "sha1-N76S2NGo5myO4S8TA+0xbYXY6zc=",
-      "dev": true
     },
     "clean-css": {
       "version": "4.2.1",
@@ -3986,19 +3860,6 @@
       "integrity": "sha1-Mh9s9zeCpv91ERE5D8BeLGV9jJs=",
       "dev": true
     },
-    "css-select-umd": {
-      "version": "1.3.0-rc0",
-      "resolved": "https://registry.npmjs.org/css-select-umd/-/css-select-umd-1.3.0-rc0.tgz",
-      "integrity": "sha512-ggouX0yWeql8nZobF5jscijHx/WIDkEuy7Iq6fU2X6ogQyIPpJ/aGn4ZYM0jpfI0LbvDaQustkj0az/hN1BqwA==",
-      "dev": true,
-      "requires": {
-        "boolbase": "^1.0.0",
-        "css-what": "2.1",
-        "domutils": "1.5.1",
-        "es6-set": "^0.1.5",
-        "nth-check": "^1.0.1"
-      }
-    },
     "css-selector-tokenizer": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.1.tgz",
@@ -4044,12 +3905,6 @@
         }
       }
     },
-    "css-what": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
-      "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==",
-      "dev": true
-    },
     "cssauron": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/cssauron/-/cssauron-1.4.0.tgz",
@@ -4076,16 +3931,6 @@
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
       "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
       "dev": true
-    },
-    "d": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
-      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
-      "dev": true,
-      "requires": {
-        "es5-ext": "^0.10.50",
-        "type": "^1.0.1"
-      }
     },
     "damerau-levenshtein": {
       "version": "1.0.5",
@@ -4321,11 +4166,6 @@
         "wrappy": "1"
       }
     },
-    "dgrid": {
-      "version": "github:Esri/dgrid#200a7fda418bec199f3b76a493fdfa7d4440698b",
-      "from": "github:Esri/dgrid#v1.2.1/esri-3.22.0",
-      "dev": true
-    },
     "di": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz",
@@ -4347,14 +4187,6 @@
         "bn.js": "^4.1.0",
         "miller-rabin": "^4.0.0",
         "randombytes": "^2.0.0"
-      }
-    },
-    "dijit": {
-      "version": "github:Esri/dijit#ae2ed989408cbbadefcb4d5811b45fe7269b0e4e",
-      "from": "github:Esri/dijit#v1.14.2/esri-3.28.0",
-      "dev": true,
-      "requires": {
-        "dojo": "1.14.2"
       }
     },
     "dir-glob": {
@@ -4391,87 +4223,6 @@
         "buffer-indexof": "^1.0.0"
       }
     },
-    "dojo": {
-      "version": "github:Esri/dojo#bed2e881e70d2d5f52a7423af2ec1f6036eb9b0c",
-      "from": "github:Esri/dojo#v1.14.2/esri-3.28.0",
-      "dev": true
-    },
-    "dojo-dstore": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/dojo-dstore/-/dojo-dstore-1.1.2.tgz",
-      "integrity": "sha1-zuNpmfP4B9HP/P32FX2w8rI3zeQ=",
-      "dev": true,
-      "requires": {
-        "dojo": "^1.9.0"
-      }
-    },
-    "dojo-util": {
-      "version": "github:Esri/dojo-util#6cedc661ffef874e75f393f0212a9134dec96cd4",
-      "from": "github:Esri/dojo-util#v1.14.2/esri-3.28.0",
-      "dev": true
-    },
-    "dojo-webpack-plugin": {
-      "version": "2.8.9",
-      "resolved": "https://registry.npmjs.org/dojo-webpack-plugin/-/dojo-webpack-plugin-2.8.9.tgz",
-      "integrity": "sha512-IR0ADttdOBLJX19l17gg3VpH5yN7ywH69EpJb42iSVOGh8CM3uZj3luC1awyWbJtchVq71bZCLV5O8BgUUPfFg==",
-      "dev": true,
-      "requires": {
-        "loader-utils": "1.1.0",
-        "node-stringify": "0.2.1",
-        "raw-loader": "0.5.1",
-        "tmp": "0.0.30",
-        "webpack-plugin-compat": "1.0.1"
-      },
-      "dependencies": {
-        "big.js": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-          "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
-          "dev": true
-        },
-        "json5": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-          "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-          "dev": true
-        },
-        "loader-utils": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
-          "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-          "dev": true,
-          "requires": {
-            "big.js": "^3.1.3",
-            "emojis-list": "^2.0.0",
-            "json5": "^0.5.0"
-          }
-        },
-        "raw-loader": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-0.5.1.tgz",
-          "integrity": "sha1-DD0L6u2KAclm2Xh793goElKpeao=",
-          "dev": true
-        },
-        "tmp": {
-          "version": "0.0.30",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.30.tgz",
-          "integrity": "sha1-ckGdSovn1s51FI/YsyTlk6cRwu0=",
-          "dev": true,
-          "requires": {
-            "os-tmpdir": "~1.0.1"
-          }
-        }
-      }
-    },
-    "dojox": {
-      "version": "github:Esri/dojox#66a4f9a49808332c0573437ea2f9f78901124373",
-      "from": "github:Esri/dojox#v1.14.2/esri-3.28.0",
-      "dev": true,
-      "requires": {
-        "dijit": "1.14.2",
-        "dojo": "1.14.2"
-      }
-    },
     "dom-serialize": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/dom-serialize/-/dom-serialize-2.2.1.tgz",
@@ -4484,45 +4235,11 @@
         "void-elements": "^2.0.0"
       }
     },
-    "dom-serializer": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.1.tgz",
-      "integrity": "sha512-sK3ujri04WyjwQXVoK4PU3y8ula1stq10GJZpqHIUgoGZdsGzAGu65BnU3d08aTVSvO7mGPZUc0wTEDL+qGE0Q==",
-      "dev": true,
-      "requires": {
-        "domelementtype": "^2.0.1",
-        "entities": "^2.0.0"
-      },
-      "dependencies": {
-        "domelementtype": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
-          "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==",
-          "dev": true
-        }
-      }
-    },
     "domain-browser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
       "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
       "dev": true
-    },
-    "domelementtype": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
-      "dev": true
-    },
-    "domutils": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-      "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
-      "dev": true,
-      "requires": {
-        "dom-serializer": "0",
-        "domelementtype": "1"
-      }
     },
     "duplexify": {
       "version": "3.7.1",
@@ -4740,12 +4457,6 @@
       "integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0=",
       "dev": true
     },
-    "entities": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
-      "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==",
-      "dev": true
-    },
     "err-code": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
@@ -4799,28 +4510,6 @@
         "is-symbol": "^1.0.2"
       }
     },
-    "es5-ext": {
-      "version": "0.10.51",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.51.tgz",
-      "integrity": "sha512-oRpWzM2WcLHVKpnrcyB7OW8j/s67Ba04JCm0WnNv3RiABSvs7mrQlutB8DBv793gKcp0XENR8Il8WxGTlZ73gQ==",
-      "dev": true,
-      "requires": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.1",
-        "next-tick": "^1.0.0"
-      }
-    },
-    "es6-iterator": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-      "dev": true,
-      "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.35",
-        "es6-symbol": "^3.1.1"
-      }
-    },
     "es6-promise": {
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
@@ -4834,29 +4523,6 @@
       "dev": true,
       "requires": {
         "es6-promise": "^4.0.3"
-      }
-    },
-    "es6-set": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
-      "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
-      "dev": true,
-      "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14",
-        "es6-iterator": "~2.0.1",
-        "es6-symbol": "3.1.1",
-        "event-emitter": "~0.3.5"
-      }
-    },
-    "es6-symbol": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-      "dev": true,
-      "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
       }
     },
     "escape-html": {
@@ -4896,11 +4562,6 @@
         "estraverse": "^4.1.0"
       }
     },
-    "esri-loader": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/esri-loader/-/esri-loader-2.10.0.tgz",
-      "integrity": "sha512-CNC4sL1izSLphkToy1vVCm3iORCSuBE5iw+S9uq26Aq/5pgSIiwLkqKo9ky+Wd8fznQ8VdN1X3Aen8yaTb7KDQ=="
-    },
     "estraverse": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
@@ -4918,16 +4579,6 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
-    },
-    "event-emitter": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-      "dev": true,
-      "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
-      }
     },
     "eventemitter3": {
       "version": "3.1.2",
@@ -5617,15 +5268,6 @@
         }
       }
     },
-    "globalize": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/globalize/-/globalize-1.4.0.tgz",
-      "integrity": "sha1-TACnneZ9c5qbf/g7ZrkNAlfCdJM=",
-      "dev": true,
-      "requires": {
-        "cldrjs": "^0.5.0"
-      }
-    },
     "globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -6189,12 +5831,6 @@
         "default-gateway": "^4.2.0",
         "ipaddr.js": "^1.9.0"
       }
-    },
-    "intersection-observer": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/intersection-observer/-/intersection-observer-0.4.2.tgz",
-      "integrity": "sha512-SFGCL4d6A7J+aXNHTx94zV7ydngTKraDBvoJjn5iGgsXYhXgAXIYj8i3ewJoO80BRB7qtBB3sBlrdGNwTktzLg==",
-      "dev": true
     },
     "invariant": {
       "version": "2.2.4",
@@ -7862,24 +7498,6 @@
         "object-visit": "^1.0.0"
       }
     },
-    "maquette": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/maquette/-/maquette-3.3.4.tgz",
-      "integrity": "sha512-x54CADeqUXJaCpj7UNF/mnCh+KAzyOzMDD2OS0SDOT+pjcHdkUzpumFfL4eFrmAgf65B+FvT9H4CIyU2tqrfhg==",
-      "dev": true
-    },
-    "maquette-css-transitions": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/maquette-css-transitions/-/maquette-css-transitions-1.1.1.tgz",
-      "integrity": "sha512-EYKVwF+vYGt7rcPUx+Kk9Dy7Yyw3PC+8mmt5/VgB89H3zBaSLtFUZ4Deg/5HDy9xFrGoh2Zx85DL49/Vll3yJQ==",
-      "dev": true
-    },
-    "maquette-jsx": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/maquette-jsx/-/maquette-jsx-2.1.1.tgz",
-      "integrity": "sha512-mE6ILC4SCcDY2Evra+SPYSVYJ5qbpuPSXR+KpZm+4LfQ1/7lGtij25hFJhMg8k/RUQNm+wWNpklpyC05kGdR0A==",
-      "dev": true
-    },
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -8186,12 +7804,6 @@
         }
       }
     },
-    "moment": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
-      "dev": true
-    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -8272,12 +7884,6 @@
       "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
       "dev": true
     },
-    "next-tick": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
-      "dev": true
-    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -8356,12 +7962,6 @@
           "dev": true
         }
       }
-    },
-    "node-stringify": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/node-stringify/-/node-stringify-0.2.1.tgz",
-      "integrity": "sha512-EdzBiPO2hmQOpG8eZtJmBK0bAWPTdla2GAU4Tb7fztLkAiMEYcJAHWvC/4FI8E9ZOxB1zmoAJpM6upTQ54xNDw==",
-      "dev": true
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -8485,25 +8085,10 @@
         "path-key": "^2.0.0"
       }
     },
-    "nth-check": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
-      "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
-      "dev": true,
-      "requires": {
-        "boolbase": "~1.0.0"
-      }
-    },
     "null-check": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/null-check/-/null-check-1.0.0.tgz",
       "integrity": "sha1-l33/1xdgErnsMNKjnbXPcqBDnt0=",
-      "dev": true
-    },
-    "null-loader": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/null-loader/-/null-loader-0.1.1.tgz",
-      "integrity": "sha1-F76av80/8OFRL2/Er8sfUDk3j64=",
       "dev": true
     },
     "num2fraction": {
@@ -9003,12 +8588,6 @@
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
       }
-    },
-    "pepjs": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/pepjs/-/pepjs-0.4.2.tgz",
-      "integrity": "sha1-EyZO6olJhP9CPIPkDS+k4d7Byfo=",
-      "dev": true
     },
     "performance-now": {
       "version": "2.1.0",
@@ -9655,38 +9234,6 @@
         "picomatch": "^2.0.4"
       }
     },
-    "recast": {
-      "version": "0.11.23",
-      "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
-      "integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=",
-      "dev": true,
-      "requires": {
-        "ast-types": "0.9.6",
-        "esprima": "~3.1.0",
-        "private": "~0.1.5",
-        "source-map": "~0.5.0"
-      },
-      "dependencies": {
-        "ast-types": {
-          "version": "0.9.6",
-          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.6.tgz",
-          "integrity": "sha1-ECyenpAF0+fjgpvwxPok7oYu6bk=",
-          "dev": true
-        },
-        "esprima": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
-        }
-      }
-    },
     "reflect-metadata": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
@@ -9856,12 +9403,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
-      "dev": true
-    },
-    "resize-observer-polyfill": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.0.tgz",
-      "integrity": "sha512-M2AelyJDVR/oLnToJLtuDJRBBWUGUvvGigj1411hXhAdyFWqMaqHp7TixW3FpiLuVaikIcR1QL+zqoJoZlOgpg==",
       "dev": true
     },
     "resolve": {
@@ -11413,12 +10954,6 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
     },
-    "type": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
-      "dev": true
-    },
     "type-fest": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.5.2.tgz",
@@ -11452,6 +10987,7 @@
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
       "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "commander": "~2.20.0",
         "source-map": "~0.6.1"
@@ -11461,7 +10997,8 @@
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -11470,17 +11007,6 @@
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
       "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
       "dev": true
-    },
-    "umd-compat-loader": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/umd-compat-loader/-/umd-compat-loader-2.1.2.tgz",
-      "integrity": "sha512-RkTlsfrCxUISWqiTtYFFJank7b2Hhl4V2pc29nl0xOEGvvuVkpy1xnufhXfTituxgpW0HSrDk0JHlvPYZxEXKQ==",
-      "dev": true,
-      "requires": {
-        "ast-types": "^0.9.2",
-        "loader-utils": "^1.0.3",
-        "recast": "^0.11.17"
-      }
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
@@ -11649,25 +11175,6 @@
           "version": "1.3.2",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
           "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
-          "dev": true
-        }
-      }
-    },
-    "url-loader": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-1.1.2.tgz",
-      "integrity": "sha512-dXHkKmw8FhPqu8asTc1puBfe3TehOCo2+RmOOev5suNCIYBcT626kxiWg1NBVkwc4rO8BGa7gP70W7VXuqHrjg==",
-      "dev": true,
-      "requires": {
-        "loader-utils": "^1.1.0",
-        "mime": "^2.0.3",
-        "schema-utils": "^1.0.0"
-      },
-      "dependencies": {
-        "mime": {
-          "version": "2.4.4",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
-          "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
           "dev": true
         }
       }
@@ -12522,12 +12029,6 @@
         "minimalistic-assert": "^1.0.0"
       }
     },
-    "web-animations-js": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/web-animations-js/-/web-animations-js-2.3.1.tgz",
-      "integrity": "sha1-Om2bwVGWN3qQ+OKAP6UmIWWwRRA=",
-      "dev": true
-    },
     "webdriver-js-extender": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/webdriver-js-extender/-/webdriver-js-extender-2.1.0.tgz",
@@ -13350,15 +12851,6 @@
         }
       }
     },
-    "webpack-hasjs-plugin": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/webpack-hasjs-plugin/-/webpack-hasjs-plugin-1.0.3.tgz",
-      "integrity": "sha512-az+/ImZp874d+4TU5ZFPC9Iw8bjH1YtvcNs17JdNyt7lhZx1UxnKLntDgzWFfpKQ4g+tFBWn2/LrDmxrhnofhw==",
-      "dev": true,
-      "requires": {
-        "webpack-plugin-compat": "^1.0.1"
-      }
-    },
     "webpack-log": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/webpack-log/-/webpack-log-2.0.0.tgz",
@@ -13377,12 +12869,6 @@
       "requires": {
         "lodash": "^4.17.5"
       }
-    },
-    "webpack-plugin-compat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/webpack-plugin-compat/-/webpack-plugin-compat-1.0.1.tgz",
-      "integrity": "sha512-mCFeieoXJDqFecib1ofvpHB+NqxRWHbZ5/NSlUa7Myb1j24zkCUS/0+r+i5VPyvUvCxQ/cLvMc5pj+6CHmv/gA==",
-      "dev": true
     },
     "webpack-sources": {
       "version": "1.4.3",
@@ -13426,12 +12912,6 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
       "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==",
-      "dev": true
-    },
-    "whatwg-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==",
       "dev": true
     },
     "when": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "@angular/platform-browser-dynamic": "~8.2.3",
     "@angular/router": "~8.2.3",
     "@types/arcgis-js-api": "^4.12.0",
-    "esri-loader": "^2.10.0",
     "rxjs": "~6.4.0",
     "tslib": "^1.10.0",
     "zone.js": "~0.9.1"
@@ -31,7 +30,6 @@
     "@angular/cli": "~8.3.0",
     "@angular/compiler-cli": "~8.2.3",
     "@angular/language-service": "~8.2.3",
-    "@arcgis/webpack-plugin": "^4.12.2",
     "@types/jasmine": "~3.3.8",
     "@types/jasminewd2": "~2.0.3",
     "@types/node": "~8.9.4",

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -6,7 +6,7 @@
       ArcGIS API for JavaScript
     </a>
     <br>
-    And, arcgis-webpack-plugin
+    No esri-loader or arcgis-webpack-plugin dependencies needed
     <br>
     with . . .
   </h1>

--- a/src/app/esri-map/esri-map.component.ts
+++ b/src/app/esri-map/esri-map.component.ts
@@ -12,9 +12,9 @@
 */
 
 import { Component, OnInit, OnDestroy, ViewChild, ElementRef, Input, Output, EventEmitter } from '@angular/core';
-import Map from "arcgis-js-api/Map";
-import MapView from "arcgis-js-api/views/MapView";
-import esri = __esri; // Esri TypeScript Types
+import esri = __esri;
+import Map from "esri/Map";
+import MapView from "esri/views/MapView";
 
 @Component({
   selector: 'app-esri-map',
@@ -32,7 +32,7 @@ export class EsriMapComponent implements OnInit, OnDestroy {
   private _center: Array<number> = [0.1278, 51.5074];
   private _basemap = 'streets';
   private _loaded = false;
-  private _view: esri.MapView = null;
+  private _view: MapView = null;
 
   get mapLoaded(): boolean {
     return this._loaded;
@@ -75,7 +75,7 @@ export class EsriMapComponent implements OnInit, OnDestroy {
         basemap: this._basemap
       };
 
-      const map: esri.Map = new Map(mapProperties);
+      const map = new Map(mapProperties);
 
       // Initialize the MapView
       const mapViewProperties: esri.MapViewProperties = {

--- a/src/index.html
+++ b/src/index.html
@@ -6,8 +6,10 @@
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <link rel="stylesheet" href="https://js.arcgis.com/4.12/esri/themes/light/main.css">
 </head>
 <body>
+  <script src="https://js.arcgis.com/4.12/"></script>
   <app-root></app-root>
 </body>
 </html>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,22 +3,22 @@
   "compilerOptions": {
     "baseUrl": "./",
     "outDir": "./dist/out-tsc",
+    "types": ["arcgis-js-api"],
     "sourceMap": true,
     "declaration": false,
     "downlevelIteration": true,
     "experimentalDecorators": true,
     "module": "esnext",
     "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
     "importHelpers": true,
-    "target": "es5",
+    "target": "es2015",
     "typeRoots": [
       "node_modules/@types"
     ],
     "lib": [
       "dom",
-      "es2015.promise",
-      "es5",
-      "es6"
+      "es2018"
     ]
   }
   // [NOTE: these options simply haven't been tested yet with the angular-cli-esri-map components]


### PR DESCRIPTION
This is a straightforward solution for developing arcgis apps in Angular without dependencies of esri-loader or arcgis-webpack-plugin. The former doesn't provide a typical angular development experience and the latter dramatically increases build times. This solution simply configures webpack to ignore bundling arcgis jsapi, and instead it loads from the CDN at runtime. This prevents lengthy builds and allows devs to import types normally in Angular versus how it's done in esri-loader. 

May want to create a separate branch for this instead of merging. 